### PR TITLE
Fix race condition in AudioPlayer

### DIFF
--- a/src/org/servalproject/audio/AudioPlayer.java
+++ b/src/org/servalproject/audio/AudioPlayer.java
@@ -212,7 +212,7 @@ public class AudioPlayer implements Runnable {
 	}
 
 	public synchronized void cleanup() {
-		if (audioOutput == null)
+		if (audioOutput == null || playbackThread != null)
 			return;
 
 		try {
@@ -407,8 +407,9 @@ public class AudioPlayer implements Runnable {
 			}
 		}
 		am.setMode(oldAudioMode);
-		cleanup();
 		playbackThread = null;
+		cleanup();
+
 	}
 
 }


### PR DESCRIPTION
AudioPlayer.cleanup() is called both from the playback thread when it is shutting down, and from the AudioManager when it gets the CallEnded message from servald. The playback thread will throw an NPE if it attempts to shutdown when cleanup() has already been called.
