### PR TITLE
Peer list concurrent access crash (fix #71)

### DIFF
--- a/src/org/servalproject/PeerList.java
+++ b/src/org/servalproject/PeerList.java
@@ -20,7 +20,7 @@
 package org.servalproject;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -41,7 +41,6 @@ import android.app.ListActivity;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.os.Handler;
 import android.os.SystemClock;
 import android.util.Log;
 import android.view.View;
@@ -62,7 +61,6 @@ public class PeerList extends ListActivity {
 	PeerListAdapter listAdapter;
 
 	private boolean displayed = false;
-	private boolean refreshing = false;
 	private static final String TAG = "PeerList";
 
 	public static final String PICK_PEER_INTENT = "org.servalproject.PICK_FROM_PEER_LIST";
@@ -77,13 +75,11 @@ public class PeerList extends ListActivity {
 	private boolean returnResult = false;
 
 	List<IPeer> peers = new ArrayList<IPeer>();
-	private Handler handler;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		handler = new Handler();
 		Intent intent = getIntent();
 		if (intent != null) {
 			if (PICK_PEER_INTENT.equals(intent.getAction())) {
@@ -143,23 +139,13 @@ public class PeerList extends ListActivity {
 		}
 	}
 
-	// list sorter that preserves new items added to the end in a different
-	// thread, unlike Collections.sort which just crashes.
-	private void sort() {
-		IPeer array[] = peers.toArray(new IPeer[peers.size()]);
-		Arrays.sort(array, new PeerComparator());
-		for (int i = 0; i < peers.size() && i < array.length; i++)
-			peers.set(i, array[i]);
-	}
-
-	private Runnable updateList = new Runnable() {
-		@Override
-		public void run() {
-			if (!refreshing)
-				sort();
+	private void addPeerIfNeeded(IPeer p) {
+		if (!peers.contains(p)) {
+			peers.add(p);
+			Collections.sort(peers, new PeerComparator());
 			listAdapter.notifyDataSetChanged();
 		}
-	};
+	}
 
 	private IPeerListListener listener = new IPeerListListener() {
 		@Override
@@ -173,13 +159,14 @@ public class PeerList extends ListActivity {
 			if (p.cacheUntil <= SystemClock.elapsedRealtime())
 				resolve(p);
 
-			// TODO map lookup?
-			int pos = peers.indexOf(p);
-			if (pos < 0)
-				peers.add(p);
+			runOnUiThread(new Runnable() {
 
-			handler.removeCallbacks(updateList);
-			handler.postDelayed(updateList, 50);
+				@Override
+				public void run() {
+					addPeerIfNeeded(p);
+				};
+
+			});
 		}
 	};
 
@@ -231,7 +218,6 @@ public class PeerList extends ListActivity {
 
 	private synchronized void refresh() {
 		final long now = SystemClock.elapsedRealtime();
-		refreshing = true;
 		ServalD.peers(new AbstractJniResults() {
 
 			@Override
@@ -245,17 +231,21 @@ public class PeerList extends ListActivity {
 					PeerListService.peerReachable(getContentResolver(),
 							sid, true);
 
-					Peer p = PeerListService.getPeer(
+					final Peer p = PeerListService.getPeer(
 							getContentResolver(), sid);
 					p.lastSeen = now;
 
-					if (peers.indexOf(p) < 0) {
-						peers.add(p);
-						PeerList.this.runOnUiThread(updateList);
-					}
-
 					if (p.cacheUntil <= SystemClock.elapsedRealtime())
 						unresolved.put(p.sid, p);
+
+					runOnUiThread(new Runnable() {
+
+						@Override
+						public void run() {
+							addPeerIfNeeded(p);
+						};
+
+					});
 
 				} catch (InvalidHexException e) {
 					Log.e(TAG, e.toString(), e);
@@ -263,12 +253,8 @@ public class PeerList extends ListActivity {
 			}
 		});
 
-		refreshing = false;
-
 		if (!displayed)
 			return;
-
-		PeerList.this.runOnUiThread(updateList);
 
 		for (Peer p : PeerListService.peers.values()) {
 			if (p.lastSeen < now)


### PR DESCRIPTION
I had the same error as you had in bug https://github.com/servalproject/batphone/issues/71.

Here is my analysis.

When we need to access and modify an ArrayList from two different threads, there are typically two solutions:
1. synchronize access (mutex);
2. serialize the calls in a FIFO queue for making them happen in _one_ thread.

As `peers` variable is used as `PeerListAdapter` backend, we **must** choose the second solution, and the thread **must** be the _UI thread_.

Currently, wrong access to `peers` occur at two places:
- in `listener`, `peerChanged(...)` modifies `peers` from outside the _UI thread_;
- in `refresh()`, the `AbstractJniResults.putBlob(...)` method does the same.

The comments on the `sort()` method suggests the problem already happened and has been _workarounded_:

``` java
    // list sorter that preserves new items added to the end in a different
    // thread, unlike Collections.sort which just crashes.
    private void sort() {
        IPeer array[] = peers.toArray(new IPeer[peers.size()]);
        Arrays.sort(array, new PeerComparator());
        for (int i = 0; i < peers.size() && i < array.length; i++)
            peers.set(i, array[i]);
    }
```

This kind of workaround avoids to crash, but can result in an incorrect display (a missing item for example).

The fix I propose consists in always accessing/modifying `peers` in the _UI thread_.
It removes the need of the `handler`, the `refreshing` variable and the custom `sort()` method.
It also allows to sort and notify only when needed (when an item is added).
